### PR TITLE
[WIP] Add controller `/content-check`

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -14,6 +14,7 @@ const activityDetailsController = require('./controllers/activity-details-contro
 
 const i18n = require('./middleware/i18n');
 const healthCheckController = require('./controllers/health-check-controller');
+const contentCheckController = require('./controllers/content-check-controller');
 
 const app = express();
 i18n(app);
@@ -31,6 +32,8 @@ const googleTagManagerId = process.env.GOOGLE_TAG_MANAGER_ID;
 
 app.use('/health_check', healthCheckController);
 app.use(`${basePath}/health_check`, healthCheckController);
+
+app.use(`${basePath}/content_check`, contentCheckController);
 
 // Middleware to set default layouts.
 // This must be done per request (and not via app.locals) as the Consolidate.js

--- a/app/controllers/content-check-controller.js
+++ b/app/controllers/content-check-controller.js
@@ -1,0 +1,14 @@
+const express = require('express');
+const router = new express.Router();
+const UrlChecker = require('../utils/url-checker');
+
+const links = require('./../models/activities')
+  .map(activity => `http://localhost:3000/a7031314-c8e5-4e80-b0eb-cd46a5b8dc45/activities/${activity}`);
+
+
+router.get('', (req, res) =>
+  new UrlChecker().checkForDeadLinks(links)
+    .then(deadLinks => res.json(deadLinks))
+);
+
+module.exports = router;

--- a/app/utils/url-checker.js
+++ b/app/utils/url-checker.js
@@ -1,0 +1,24 @@
+const blc = require('broken-link-checker');
+
+class UrlChecker {
+  checkForDeadLinks(links) {
+    return new Promise(resolve => {
+      const brokenLinks = [];
+
+      const htmlUrlChecker = new blc.HtmlUrlChecker({}, {
+        link(result) {
+          if (result.broken) {
+            brokenLinks.push({ base: result.base.original, link: result.url.original });
+          }
+        },
+        end() {
+          resolve({ brokenLinks });
+        },
+      });
+
+      links.forEach(link => htmlUrlChecker.enqueue(link));
+    });
+  }
+}
+
+module.exports = UrlChecker;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -512,6 +512,23 @@
       "from": "beeper@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz"
     },
+    "bhttp": {
+      "version": "1.2.4",
+      "from": "bhttp@>=1.2.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/bhttp/-/bhttp-1.2.4.tgz",
+      "dependencies": {
+        "extend": {
+          "version": "2.0.1",
+          "from": "extend@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz"
+        },
+        "lodash": {
+          "version": "2.4.2",
+          "from": "lodash@>=2.4.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+        }
+      }
+    },
     "bindings": {
       "version": "1.2.1",
       "from": "bindings@>=1.2.1 <2.0.0",
@@ -575,6 +592,18 @@
       "version": "1.8.5",
       "from": "braces@>=1.8.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz"
+    },
+    "broken-link-checker": {
+      "version": "0.7.4",
+      "from": "broken-link-checker@>=0.7.4 <0.8.0",
+      "resolved": "https://registry.npmjs.org/broken-link-checker/-/broken-link-checker-0.7.4.tgz",
+      "dependencies": {
+        "parse5": {
+          "version": "2.2.3",
+          "from": "parse5@>=2.1.5 <3.0.0",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-2.2.3.tgz"
+        }
+      }
     },
     "brorand": {
       "version": "1.0.6",
@@ -693,6 +722,11 @@
       "from": "callsites@>=0.2.0 <0.3.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz"
     },
+    "calmcard": {
+      "version": "0.1.1",
+      "from": "calmcard@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/calmcard/-/calmcard-0.1.1.tgz"
+    },
     "camelcase": {
       "version": "2.1.1",
       "from": "camelcase@>=2.0.0 <3.0.0",
@@ -723,6 +757,11 @@
       "from": "chalk@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
     },
+    "char-spinner": {
+      "version": "1.0.1",
+      "from": "char-spinner@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/char-spinner/-/char-spinner-1.0.1.tgz"
+    },
     "cipher-base": {
       "version": "1.0.3",
       "from": "cipher-base@>=1.0.0 <2.0.0",
@@ -738,6 +777,11 @@
       "from": "cli-cursor@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz"
     },
+    "cli-table": {
+      "version": "0.3.1",
+      "from": "cli-table@>=0.3.1 <0.4.0",
+      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz"
+    },
     "cli-width": {
       "version": "2.1.0",
       "from": "cli-width@>=2.0.0 <3.0.0",
@@ -751,12 +795,13 @@
         "configstore": {
           "version": "2.1.0",
           "from": "configstore@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/configstore/-/configstore-2.1.0.tgz"
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "from": "graceful-fs@>=4.1.2 <5.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+          "resolved": "https://registry.npmjs.org/configstore/-/configstore-2.1.0.tgz",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "4.1.11",
+              "from": "graceful-fs@>=4.1.2 <5.0.0"
+            }
+          }
         },
         "object-assign": {
           "version": "4.1.0",
@@ -815,6 +860,11 @@
       "from": "combined-stream@>=1.0.5 <1.1.0",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
     },
+    "combined-stream2": {
+      "version": "1.1.2",
+      "from": "combined-stream2@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/combined-stream2/-/combined-stream2-1.1.2.tgz"
+    },
     "commander": {
       "version": "2.9.0",
       "from": "commander@>=2.9.0 <3.0.0",
@@ -837,6 +887,11 @@
         }
       }
     },
+    "condense-whitespace": {
+      "version": "1.0.0",
+      "from": "condense-whitespace@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/condense-whitespace/-/condense-whitespace-1.0.0.tgz"
+    },
     "configstore": {
       "version": "1.4.0",
       "from": "configstore@>=1.2.0 <2.0.0",
@@ -844,7 +899,7 @@
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.11",
-          "from": "graceful-fs@>=4.1.2 <5.0.0",
+          "from": "graceful-fs@4.1.11",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
         },
         "object-assign": {
@@ -875,9 +930,9 @@
       "resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.14.5.tgz",
       "dependencies": {
         "bluebird": {
-          "version": "3.4.7",
+          "version": "3.4.6",
           "from": "bluebird@>=3.1.1 <4.0.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz"
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.6.tgz"
         }
       }
     },
@@ -1072,6 +1127,11 @@
       "from": "deep-is@>=0.1.3 <0.2.0",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
     },
+    "default-user-agent": {
+      "version": "1.0.0",
+      "from": "default-user-agent@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/default-user-agent/-/default-user-agent-1.0.0.tgz"
+    },
     "defaults": {
       "version": "1.0.3",
       "from": "defaults@>=1.0.0 <2.0.0",
@@ -1151,6 +1211,11 @@
         }
       }
     },
+    "dev-null": {
+      "version": "0.1.1",
+      "from": "dev-null@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/dev-null/-/dev-null-0.1.1.tgz"
+    },
     "diff": {
       "version": "1.4.0",
       "from": "diff@1.4.0",
@@ -1207,6 +1272,11 @@
       "version": "2.1.0-0",
       "from": "double-ended-queue@>=2.1.0-0 <3.0.0",
       "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz"
+    },
+    "duplexer": {
+      "version": "0.1.1",
+      "from": "duplexer@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
     },
     "duplexer2": {
       "version": "0.1.4",
@@ -1277,10 +1347,25 @@
       "from": "entities@>=1.1.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
     },
+    "eol": {
+      "version": "0.2.0",
+      "from": "eol@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/eol/-/eol-0.2.0.tgz"
+    },
+    "errno": {
+      "version": "0.1.4",
+      "from": "errno@>=0.1.4 <0.2.0",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz"
+    },
     "error-ex": {
       "version": "1.3.0",
       "from": "error-ex@>=1.2.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz"
+    },
+    "errors": {
+      "version": "0.2.0",
+      "from": "errors@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/errors/-/errors-0.2.0.tgz"
     },
     "es5-ext": {
       "version": "0.10.12",
@@ -1607,8 +1692,7 @@
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.11",
-          "from": "graceful-fs@>=4.1.2 <5.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+          "from": "graceful-fs@>=4.1.2 <5.0.0"
         }
       }
     },
@@ -1637,6 +1721,28 @@
       "from": "form-data@>=2.1.1 <2.2.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz"
     },
+    "form-data2": {
+      "version": "1.0.3",
+      "from": "form-data2@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/form-data2/-/form-data2-1.0.3.tgz",
+      "dependencies": {
+        "lodash": {
+          "version": "2.4.2",
+          "from": "lodash@2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+        },
+        "uuid": {
+          "version": "2.0.3",
+          "from": "uuid@>=2.0.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz"
+        }
+      }
+    },
+    "form-fix-array": {
+      "version": "1.0.0",
+      "from": "form-fix-array@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/form-fix-array/-/form-fix-array-1.0.0.tgz"
+    },
     "forwarded": {
       "version": "0.1.0",
       "from": "forwarded@>=0.1.0 <0.2.0",
@@ -1664,8 +1770,7 @@
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.11",
-          "from": "graceful-fs@>=4.1.2 <5.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+          "from": "graceful-fs@>=4.1.2 <5.0.0"
         }
       }
     },
@@ -1805,6 +1910,11 @@
       "from": "globby@>=5.0.0 <6.0.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
       "dependencies": {
+        "glob": {
+          "version": "7.1.1",
+          "from": "glob@>=7.0.3 <8.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
+        },
         "object-assign": {
           "version": "4.1.0",
           "from": "object-assign@>=4.0.1 <5.0.0",
@@ -2042,6 +2152,11 @@
       "from": "htmlparser2@>=3.7.3 <4.0.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz"
     },
+    "http-equiv-refresh": {
+      "version": "1.0.0",
+      "from": "http-equiv-refresh@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/http-equiv-refresh/-/http-equiv-refresh-1.0.0.tgz"
+    },
     "http-errors": {
       "version": "1.3.1",
       "from": "http-errors@>=1.3.1 <1.4.0",
@@ -2056,6 +2171,11 @@
       "version": "0.0.1",
       "from": "https-browserify@>=0.0.0 <0.1.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz"
+    },
+    "humanize-duration": {
+      "version": "3.10.0",
+      "from": "humanize-duration@>=3.9.1 <4.0.0",
+      "resolved": "https://registry.npmjs.org/humanize-duration/-/humanize-duration-3.10.0.tgz"
     },
     "i18n": {
       "version": "0.8.3",
@@ -2177,6 +2297,11 @@
       "from": "is-arrayish@>=0.2.1 <0.3.0",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
     },
+    "is-browser": {
+      "version": "2.0.1",
+      "from": "is-browser@>=2.0.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/is-browser/-/is-browser-2.0.1.tgz"
+    },
     "is-buffer": {
       "version": "1.1.4",
       "from": "is-buffer@>=1.1.0 <2.0.0",
@@ -2242,6 +2367,11 @@
       "from": "is-obj@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz"
     },
+    "is-object": {
+      "version": "1.0.1",
+      "from": "is-object@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz"
+    },
     "is-path-cwd": {
       "version": "1.0.0",
       "from": "is-path-cwd@>=1.0.0 <2.0.0",
@@ -2302,6 +2432,11 @@
       "from": "is-stream@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
     },
+    "is-string": {
+      "version": "1.0.4",
+      "from": "is-string@>=1.0.4 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.4.tgz"
+    },
     "is-typedarray": {
       "version": "1.0.0",
       "from": "is-typedarray@>=1.0.0 <1.1.0",
@@ -2326,6 +2461,11 @@
       "version": "1.0.0",
       "from": "isarray@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+    },
+    "isbot": {
+      "version": "2.0.1",
+      "from": "isbot@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/isbot/-/isbot-2.0.1.tgz"
     },
     "isexe": {
       "version": "1.1.2",
@@ -2479,9 +2619,9 @@
       "resolved": "https://registry.npmjs.org/knex/-/knex-0.11.10.tgz",
       "dependencies": {
         "bluebird": {
-          "version": "3.4.7",
+          "version": "3.4.6",
           "from": "bluebird@>=3.3.4 <4.0.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz"
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.6.tgz"
         },
         "interpret": {
           "version": "0.6.6",
@@ -2556,6 +2696,16 @@
       "version": "2.3.0",
       "from": "liftoff@>=2.1.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.3.0.tgz"
+    },
+    "limited-request-queue": {
+      "version": "2.0.0",
+      "from": "limited-request-queue@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/limited-request-queue/-/limited-request-queue-2.0.0.tgz"
+    },
+    "link-types": {
+      "version": "1.1.0",
+      "from": "link-types@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/link-types/-/link-types-1.1.0.tgz"
     },
     "load-json-file": {
       "version": "1.1.0",
@@ -2804,6 +2954,11 @@
       "from": "math-interval-parser@>=1.1.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/math-interval-parser/-/math-interval-parser-1.1.0.tgz"
     },
+    "maybe-callback": {
+      "version": "2.1.0",
+      "from": "maybe-callback@>=2.1.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/maybe-callback/-/maybe-callback-2.1.0.tgz"
+    },
     "media-typer": {
       "version": "0.3.0",
       "from": "media-typer@0.3.0",
@@ -2811,7 +2966,7 @@
     },
     "meow": {
       "version": "3.7.0",
-      "from": "meow@>=3.7.0 <4.0.0",
+      "from": "meow@>=3.3.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "dependencies": {
         "object-assign": {
@@ -2880,7 +3035,7 @@
     },
     "minimatch": {
       "version": "3.0.3",
-      "from": "minimatch@>=3.0.2 <4.0.0",
+      "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
     },
     "minimist": {
@@ -3004,10 +3159,14 @@
       "from": "node-gyp@>=3.3.1 <4.0.0",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.4.0.tgz",
       "dependencies": {
+        "glob": {
+          "version": "7.1.1",
+          "from": "glob@>=7.0.3 <8.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
+        },
         "graceful-fs": {
           "version": "4.1.11",
-          "from": "graceful-fs@>=4.1.2 <5.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+          "from": "graceful-fs@>=4.1.2 <5.0.0"
         },
         "npmlog": {
           "version": "3.1.2",
@@ -3025,6 +3184,11 @@
           "version": "1.1.2",
           "from": "gaze@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz"
+        },
+        "glob": {
+          "version": "7.1.1",
+          "from": "glob@>=7.0.3 <8.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
         },
         "globule": {
           "version": "1.1.0",
@@ -3052,6 +3216,53 @@
       "version": "3.0.6",
       "from": "nopt@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz"
+    },
+    "nopter": {
+      "version": "0.3.0",
+      "from": "nopter@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/nopter/-/nopter-0.3.0.tgz",
+      "dependencies": {
+        "ansi-regex": {
+          "version": "0.2.1",
+          "from": "ansi-regex@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+        },
+        "ansi-styles": {
+          "version": "1.1.0",
+          "from": "ansi-styles@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+        },
+        "camelcase": {
+          "version": "1.2.1",
+          "from": "camelcase@>=1.0.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+        },
+        "chalk": {
+          "version": "0.5.1",
+          "from": "chalk@>=0.5.1 <0.6.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz"
+        },
+        "has-ansi": {
+          "version": "0.1.0",
+          "from": "has-ansi@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz"
+        },
+        "object-assign": {
+          "version": "2.1.1",
+          "from": "object-assign@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
+        },
+        "strip-ansi": {
+          "version": "0.3.0",
+          "from": "strip-ansi@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz"
+        },
+        "supports-color": {
+          "version": "0.2.0",
+          "from": "supports-color@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+        }
+      }
     },
     "normalize-package-data": {
       "version": "2.3.5",
@@ -3246,6 +3457,11 @@
       "from": "parse-asn1@>=5.0.0 <6.0.0",
       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.0.0.tgz"
     },
+    "parse-domain": {
+      "version": "0.2.2",
+      "from": "parse-domain@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/parse-domain/-/parse-domain-0.2.2.tgz"
+    },
     "parse-filepath": {
       "version": "1.0.1",
       "from": "parse-filepath@>=1.0.1 <2.0.0",
@@ -3328,8 +3544,7 @@
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.11",
-          "from": "graceful-fs@>=4.1.2 <5.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+          "from": "graceful-fs@>=4.1.2 <5.0.0"
         }
       }
     },
@@ -3467,6 +3682,11 @@
       "version": "1.1.2",
       "from": "proxy-addr@>=1.1.2 <1.2.0",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.2.tgz"
+    },
+    "prr": {
+      "version": "0.0.0",
+      "from": "prr@>=0.0.0 <0.1.0",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -3712,12 +3932,34 @@
     "rimraf": {
       "version": "2.5.4",
       "from": "rimraf@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz"
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+      "dependencies": {
+        "glob": {
+          "version": "7.1.1",
+          "from": "glob@>=7.0.5 <8.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
+        }
+      }
     },
     "ripemd160": {
       "version": "1.0.1",
       "from": "ripemd160@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.1.tgz"
+    },
+    "robot-directives": {
+      "version": "0.3.0",
+      "from": "robot-directives@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/robot-directives/-/robot-directives-0.3.0.tgz"
+    },
+    "robots-txt-guard": {
+      "version": "0.1.0",
+      "from": "robots-txt-guard@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/robots-txt-guard/-/robots-txt-guard-0.1.0.tgz"
+    },
+    "robots-txt-parse": {
+      "version": "0.0.4",
+      "from": "robots-txt-parse@>=0.0.4 <0.1.0",
+      "resolved": "https://registry.npmjs.org/robots-txt-parse/-/robots-txt-parse-0.0.4.tgz"
     },
     "run-async": {
       "version": "2.3.0",
@@ -3742,7 +3984,14 @@
     "sass-graph": {
       "version": "2.1.2",
       "from": "sass-graph@>=2.1.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.1.2.tgz"
+      "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.1.2.tgz",
+      "dependencies": {
+        "glob": {
+          "version": "7.1.1",
+          "from": "glob@>=7.0.0 <8.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
+        }
+      }
     },
     "scandirectory": {
       "version": "2.5.0",
@@ -3827,7 +4076,7 @@
     },
     "shell-quote": {
       "version": "1.6.1",
-      "from": "shell-quote@>=1.6.1 <2.0.0",
+      "from": "shell-quote@>=1.4.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz"
     },
     "shelljs": {
@@ -3990,6 +4239,11 @@
       "from": "split@>=0.3.0 <0.4.0",
       "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz"
     },
+    "splitargs": {
+      "version": "0.0.7",
+      "from": "splitargs@>=0.0.3 <0.1.0",
+      "resolved": "https://registry.npmjs.org/splitargs/-/splitargs-0.0.7.tgz"
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "from": "sprintf-js@>=1.0.3",
@@ -4022,6 +4276,11 @@
       "from": "stream-browserify@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz"
     },
+    "stream-combiner": {
+      "version": "0.2.2",
+      "from": "stream-combiner@>=0.2.1 <0.3.0",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz"
+    },
     "stream-combiner2": {
       "version": "1.1.1",
       "from": "stream-combiner2@>=1.1.1 <2.0.0",
@@ -4037,6 +4296,11 @@
       "from": "stream-http@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.6.0.tgz"
     },
+    "stream-length": {
+      "version": "1.0.2",
+      "from": "stream-length@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-length/-/stream-length-1.0.2.tgz"
+    },
     "stream-shift": {
       "version": "1.0.0",
       "from": "stream-shift@>=1.0.0 <2.0.0",
@@ -4046,6 +4310,11 @@
       "version": "2.0.0",
       "from": "stream-splicer@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.0.tgz"
+    },
+    "string": {
+      "version": "3.3.3",
+      "from": "string@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/string/-/string-3.3.3.tgz"
     },
     "string_decoder": {
       "version": "0.10.31",
@@ -4073,9 +4342,9 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
     },
     "strip-bom": {
-      "version": "1.0.0",
-      "from": "strip-bom@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz"
+      "version": "3.0.0",
+      "from": "strip-bom@latest",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz"
     },
     "strip-indent": {
       "version": "1.0.1",
@@ -4167,6 +4436,60 @@
       "version": "2.0.3",
       "from": "through2@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+    },
+    "through2-sink": {
+      "version": "1.0.0",
+      "from": "through2-sink@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/through2-sink/-/through2-sink-1.0.0.tgz",
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "from": "isarray@0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "from": "readable-stream@>=1.0.17 <1.1.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
+        },
+        "through2": {
+          "version": "0.5.1",
+          "from": "through2@>=0.5.1 <0.6.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz"
+        },
+        "xtend": {
+          "version": "3.0.0",
+          "from": "xtend@>=3.0.0 <3.1.0",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
+        }
+      }
+    },
+    "through2-spy": {
+      "version": "1.2.0",
+      "from": "through2-spy@>=1.2.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/through2-spy/-/through2-spy-1.2.0.tgz",
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "from": "isarray@0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "from": "readable-stream@1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
+        },
+        "through2": {
+          "version": "0.5.1",
+          "from": "through2@0.5.1",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz"
+        },
+        "xtend": {
+          "version": "3.0.0",
+          "from": "xtend@3.0.0",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
+        }
+      }
     },
     "tildify": {
       "version": "1.2.0",
@@ -4384,10 +4707,51 @@
       "from": "url-parse-lax@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz"
     },
+    "urlcache": {
+      "version": "0.6.0",
+      "from": "urlcache@>=0.6.0 <0.7.0",
+      "resolved": "https://registry.npmjs.org/urlcache/-/urlcache-0.6.0.tgz",
+      "dependencies": {
+        "object-assign": {
+          "version": "4.1.0",
+          "from": "object-assign@>=4.0.1 <5.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+        },
+        "urlobj": {
+          "version": "0.0.8",
+          "from": "urlobj@0.0.8",
+          "resolved": "https://registry.npmjs.org/urlobj/-/urlobj-0.0.8.tgz"
+        }
+      }
+    },
+    "urlobj": {
+      "version": "0.0.10",
+      "from": "urlobj@0.0.10",
+      "resolved": "https://registry.npmjs.org/urlobj/-/urlobj-0.0.10.tgz",
+      "dependencies": {
+        "object-assign": {
+          "version": "4.1.0",
+          "from": "object-assign@>=4.1.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+        }
+      }
+    },
     "user-home": {
       "version": "1.1.1",
       "from": "user-home@>=1.1.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+    },
+    "useragent": {
+      "version": "2.1.10",
+      "from": "useragent@>=2.1.8 <3.0.0",
+      "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.1.10.tgz",
+      "dependencies": {
+        "lru-cache": {
+          "version": "2.2.4",
+          "from": "lru-cache@>=2.2.0 <2.3.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz"
+        }
+      }
     },
     "util": {
       "version": "0.10.3",
@@ -4456,6 +4820,11 @@
           "from": "clone@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
         },
+        "graceful-fs": {
+          "version": "3.0.11",
+          "from": "graceful-fs@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz"
+        },
         "isarray": {
           "version": "0.0.1",
           "from": "isarray@0.0.1",
@@ -4465,6 +4834,11 @@
           "version": "1.0.34",
           "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
+        },
+        "strip-bom": {
+          "version": "1.0.0",
+          "from": "strip-bom@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz"
         },
         "through2": {
           "version": "0.6.5",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "babel-preset-es2015": "^6.9.0",
     "body-parser": "~1.13",
     "bookshelf": "^0.9.5",
+    "broken-link-checker": "^0.7.4",
     "browserify": "^13.0.1",
     "consolidate": "~0.14",
     "cookie-parser": "~1.3",
@@ -49,6 +50,7 @@
     "pg": "^4.5.5",
     "serve-favicon": "~2.3",
     "snyk": "^1.21.2",
+    "strip-bom": "^3.0.0",
     "uuid": "^3.0.1",
     "vinyl-source-stream": "^1.1.0",
     "winston": "^2.2.0"


### PR DESCRIPTION
This is mainly to illustrate how this could work inside of the application. 

Currently some of the links are hardcoded. To test you need to get this branch locally:
```
$ npm i
$ npm run watch
$ open http://localhost:3000/content_check
```

**Problems**
1. It is hard to pass `baseUrl` to `app.js` from file: `www` where we bootstrap the server.  
2. All the http request to check dead urls will be done from the server on which the application is running. This may slow down the app. 